### PR TITLE
Shutter calculation corrected

### DIFF
--- a/MAX32660/Main.c
+++ b/MAX32660/Main.c
@@ -254,7 +254,7 @@ int main(void)
     	   deltaY = ((int16_t)dataArray[5] << 8) | dataArray[4];
     	   SQUAL = dataArray[6];
     	   RawDataSum = dataArray[7];
-    	   Shutter = ((uint16_t)dataArray[11] << 8) | dataArray[10];
+    	   Shutter = ((uint16_t)dataArray[10] << 8) | dataArray[11];
     	   Shutter &= 0x1FFF;
 
     	   mode =    getMode();

--- a/PAW3902/PAW3902.ino
+++ b/PAW3902/PAW3902.ino
@@ -88,7 +88,7 @@ void loop() {
    deltaY = ((int16_t)dataArray[5] << 8) | dataArray[4];
    SQUAL = dataArray[6];
    RawDataSum = dataArray[7];
-   Shutter = ((uint16_t)dataArray[11] << 8) | dataArray[10];
+   Shutter = ((uint16_t)dataArray[10] << 8) | dataArray[11];
    Shutter &= 0x1FFF;
 
    mode =    opticalFlow.getMode();


### PR DESCRIPTION
As per PAW3901 (different sensor, but mostly same to the PAW3902) datasheet, in the burst mode "BYTE[10] = Shutter_Upper" and "BYTE[11] = Shutter_Lower".